### PR TITLE
ENH: Add ability to select retract mode for drilling ops

### DIFF
--- a/qtpyvcp_conversational_gcode/ops/drill_ops.py
+++ b/qtpyvcp_conversational_gcode/ops/drill_ops.py
@@ -88,28 +88,30 @@ class DrillOps(BaseGenerator):
         """
     def __init__(self):
         super(DrillOps, self).__init__()
+        self.retract_mode = 'G98'
         self.holes = []
 
     def drill(self):
-        return self._create_gcode('G98 G81 R%.4f Z%.4f F%.4f' %
-                                  (self.z_start + self.retract, self.z_end, self.z_feed))
+        return self._create_gcode('%s G81 R%.4f Z%.4f F%.4f' %
+                                  (self.retract_mode, self.z_start + self.retract, self.z_end, self.z_feed))
 
     def dwell(self, dwell_time=0.):
-        return self._create_gcode('G98 G82 R%.4f Z%.4f P%.4f F%.4f' %
-                                  (self.z_start + self.retract, self.z_end, dwell_time, self.z_feed))
+        return self._create_gcode('%s G82 R%.4f Z%.4f P%.4f F%.4f' %
+                                  (self.retract_mode, self.z_start + self.retract, self.z_end, dwell_time, self.z_feed))
 
     def peck(self, peck_dist=0.1):
-        return self._create_gcode('G98 G83 R%.4f Z%.4f Q%.4f F%.4f' %
-                                  (self.z_start + self.retract, self.z_end, peck_dist, self.z_feed))
+        return self._create_gcode('%s G83 R%.4f Z%.4f Q%.4f F%.4f' %
+                                  (self.retract_mode, self.z_start + self.retract, self.z_end, peck_dist, self.z_feed))
 
     def chip_break(self, break_dist=0.1):
-        return self._create_gcode('G98 G73 R%.4f Z%.4f Q%.4f F%.4f' %
-                                   (self.z_start + self.retract, self.z_end, break_dist, self.z_feed))
+        return self._create_gcode('%s G73 R%.4f Z%.4f Q%.4f F%.4f' %
+                                   (self.retract_mode, self.z_start + self.retract, self.z_end, break_dist, self.z_feed))
 
     def tap(self, pitch):
         feed = abs(self.spindle_rpm * pitch)
-        return self._create_gcode('G98 %s R%.4f Z%.4f F%.4f S%.4f' %
-                                  ('G74' if self.spindle_dir.lower() == 'ccw' else 'G84', self.z_start + self.retract,
+        return self._create_gcode('%s %s R%.4f Z%.4f F%.4f S%.4f' %
+                                  (self.retract_mode, 'G74' if self.spindle_dir.lower() == 'ccw' else 'G84',
+                                   self.z_start + self.retract,
                                    self.z_end, feed, abs(self.spindle_rpm)))
 
     def rigid_tap(self, pitch):

--- a/qtpyvcp_conversational_gcode/widgets/drill_widget.py
+++ b/qtpyvcp_conversational_gcode/widgets/drill_widget.py
@@ -5,6 +5,9 @@ class DrillWidgetBase(ConversationalBaseWidget):
     def __init__(self, ui, parent=None):
         super(DrillWidgetBase, self).__init__(ui, parent)
 
+        self.drill_retract_mode_input.addItem('G98')
+        self.drill_retract_mode_input.addItem('G99')
+
         self.drill_type_input.addItem('DRILL')
         self.drill_type_input.addItem('PECK')
         self.drill_type_input.addItem('BREAK')
@@ -31,6 +34,9 @@ class DrillWidgetBase(ConversationalBaseWidget):
 
     def tap_pitch(self):
         return self.drill_type_param_value.value()
+
+    def retract_mode(self):
+        return self.drill_retract_mode_input.currentText()
 
     def set_drill_type_params(self, _):
         self.z_feed_rate_input.setEnabled(True)

--- a/qtpyvcp_conversational_gcode/widgets/hole_circle.py
+++ b/qtpyvcp_conversational_gcode/widgets/hole_circle.py
@@ -26,6 +26,8 @@ class HoleCircleWidget(DrillWidgetBase):
     def create_op(self):
         d = DrillOps()
         self._set_common_fields(d)
+        d.retract_mode = self.retract_mode()
+
         d.add_hole_circle(num_holes=self.num_holes(),
                           circle_diam=self.circle_diameter(),
                           circle_center=self.circle_center(),

--- a/qtpyvcp_conversational_gcode/widgets/hole_circle.ui
+++ b/qtpyvcp_conversational_gcode/widgets/hole_circle.ui
@@ -1143,12 +1143,12 @@ color: rgb(255, 255, 255);
        <property name="minimumSize">
         <size>
          <width>470</width>
-         <height>430</height>
+         <height>490</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>470</width>
+         <width>490</width>
          <height>460</height>
         </size>
        </property>
@@ -1259,6 +1259,22 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="wcs_input">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
+              </property>
+             </widget>
+            </item>
             <item row="2" column="0">
              <widget class="QLabel" name="label_169">
               <property name="sizePolicy">
@@ -1293,6 +1309,22 @@ color: rgb(255, 255, 255);
               </property>
               <property name="indent">
                <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="unit_input">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
               </property>
              </widget>
             </item>
@@ -1415,7 +1447,7 @@ color: rgb(255, 255, 255);
               </item>
              </layout>
             </item>
-            <item row="4" column="0">
+            <item row="5" column="0">
              <widget class="QLabel" name="tool_number_label_3">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1452,7 +1484,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="5" column="1">
              <layout class="QHBoxLayout" name="horizontalLayout_10">
               <item>
                <widget class="IntLineEdit" name="tool_number_input">
@@ -1521,7 +1553,7 @@ color: rgb(255, 255, 255);
               </item>
              </layout>
             </item>
-            <item row="5" column="0">
+            <item row="6" column="0">
              <widget class="QLabel" name="label_170">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1558,7 +1590,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="6" column="1">
              <layout class="QHBoxLayout" name="horizontalLayout_11">
               <item>
                <widget class="FloatLineEdit" name="spindle_rpm_input">
@@ -1640,7 +1672,7 @@ color: rgb(255, 255, 255);
               </item>
              </layout>
             </item>
-            <item row="6" column="0">
+            <item row="7" column="0">
              <widget class="QLabel" name="label_172">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1677,7 +1709,23 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
+            <item row="7" column="1">
+             <widget class="QComboBox" name="coolant_input">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="0">
              <widget class="QLabel" name="label_173">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1714,7 +1762,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="7" column="1">
+            <item row="8" column="1">
              <widget class="FloatLineEdit" name="xy_feed_rate_input">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1739,7 +1787,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="8" column="0">
+            <item row="9" column="0">
              <widget class="QLabel" name="label_174">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1776,7 +1824,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="8" column="1">
+            <item row="9" column="1">
              <widget class="FloatLineEdit" name="z_feed_rate_input">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1801,7 +1849,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="10" column="0">
+            <item row="11" column="0">
              <widget class="QLabel" name="label_175">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1838,7 +1886,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="10" column="1">
+            <item row="11" column="1">
              <widget class="FloatLineEdit" name="clearance_height_input">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1863,40 +1911,45 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QComboBox" name="wcs_input">
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_176">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
-                <width>100</width>
-                <height>33</height>
+                <width>120</width>
+                <height>31</height>
                </size>
               </property>
               <property name="maximumSize">
                <size>
-                <width>100</width>
-                <height>33</height>
+                <width>120</width>
+                <height>31</height>
                </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="lineWidth">
+               <number>0</number>
+              </property>
+              <property name="text">
+               <string>RETRACT MODE</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+              <property name="indent">
+               <number>0</number>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="unit_input">
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>33</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>33</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="1">
-             <widget class="QComboBox" name="coolant_input">
+            <item row="4" column="1">
+             <widget class="QComboBox" name="drill_retract_mode_input">
               <property name="minimumSize">
                <size>
                 <width>100</width>

--- a/qtpyvcp_conversational_gcode/widgets/xy_coord.py
+++ b/qtpyvcp_conversational_gcode/widgets/xy_coord.py
@@ -97,8 +97,8 @@ class XYCoordWidget(DrillWidgetBase):
 
     def create_op(self):
         d = self.drill_op
-
         self._set_common_fields(d)
+        d.retract_mode = self.retract_mode()
 
         if self.drill_type() == 'PECK':
             op = d.peck(self.drill_peck_depth())

--- a/qtpyvcp_conversational_gcode/widgets/xy_coord.ui
+++ b/qtpyvcp_conversational_gcode/widgets/xy_coord.ui
@@ -918,7 +918,7 @@ color: rgb(255, 255, 255);
               </item>
              </layout>
             </item>
-            <item row="4" column="0">
+            <item row="5" column="0">
              <widget class="QLabel" name="tool_number_label_3">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -955,7 +955,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="5" column="1">
              <layout class="QHBoxLayout" name="horizontalLayout_10">
               <item>
                <widget class="IntLineEdit" name="tool_number_input">
@@ -1024,7 +1024,7 @@ color: rgb(255, 255, 255);
               </item>
              </layout>
             </item>
-            <item row="5" column="0">
+            <item row="6" column="0">
              <widget class="QLabel" name="label_170">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1061,7 +1061,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="6" column="1">
              <layout class="QHBoxLayout" name="horizontalLayout_11">
               <item>
                <widget class="FloatLineEdit" name="spindle_rpm_input">
@@ -1143,7 +1143,7 @@ color: rgb(255, 255, 255);
               </item>
              </layout>
             </item>
-            <item row="6" column="0">
+            <item row="7" column="0">
              <widget class="QLabel" name="label_172">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1180,7 +1180,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
+            <item row="8" column="0">
              <widget class="QLabel" name="label_173">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1217,7 +1217,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="7" column="1">
+            <item row="8" column="1">
              <widget class="FloatLineEdit" name="xy_feed_rate_input">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1242,7 +1242,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="8" column="0">
+            <item row="9" column="0">
              <widget class="QLabel" name="label_174">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1279,7 +1279,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="8" column="1">
+            <item row="9" column="1">
              <widget class="FloatLineEdit" name="z_feed_rate_input">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1304,7 +1304,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="10" column="0">
+            <item row="11" column="0">
              <widget class="QLabel" name="label_175">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1341,7 +1341,7 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="10" column="1">
+            <item row="11" column="1">
              <widget class="FloatLineEdit" name="clearance_height_input">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1398,8 +1398,61 @@ color: rgb(255, 255, 255);
               </property>
              </widget>
             </item>
-            <item row="6" column="1">
+            <item row="7" column="1">
              <widget class="QComboBox" name="coolant_input">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>33</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_176">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>31</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>120</width>
+                <height>31</height>
+               </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="lineWidth">
+               <number>0</number>
+              </property>
+              <property name="text">
+               <string>RETRACT MODE</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+              <property name="indent">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QComboBox" name="drill_retract_mode_input">
               <property name="minimumSize">
                <size>
                 <width>100</width>

--- a/tests/unit/qtpyvcp_conversational_gcode/ops/test_drilling.py
+++ b/tests/unit/qtpyvcp_conversational_gcode/ops/test_drilling.py
@@ -38,6 +38,28 @@ class TestDrilling(unittest.TestCase):
         op = self.sut.drill()
         self.assertEqual(op, expected_gcode)
 
+    def test_should_use_g99_when_specified(self):
+        expected_gcode = [
+            'G21',
+            'T4 M6 G43',
+            'S1200.0000',
+            'M3',
+            'G55',
+            'F60.0000',
+            'G0 X4.0000 Y1.0000',
+            'G0 Z0.2000',
+            'G99 G81 R1.0200 Z0.5000 F4.8000',
+            'G80',
+            'G0 Z0.2000'
+        ]
+
+        self.sut.retract_mode = 'G99'
+        self.sut.holes.append((4., 1.))
+
+        op = self.sut.drill()
+        self.assertEqual(op, expected_gcode)
+
+
     def test_should_drill_multiple_holes_at_the_given_locations(self):
         expected_gcode = [
             'G21',


### PR DESCRIPTION
Problem:
- The drilling gcode generator always used G98 when creating a drilling
  cycle. However, using G99 can save time when running the operation as
  the drill will only be retracted to the retract height between drill
  positions instead of the clearance height.

Solution:
- Add option to drill screens for setting the retract mode to either G98
  (default) or G99.